### PR TITLE
merge configured settings into ENV settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ settings = {
 CanvasStatsd.settings = settings
 ```
 
-Values passed to `CanvasStatsd.settings` will take precedence over ENV vars
+Values passed to `CanvasStatsd.settings` will be merged into and take precedence over any existing ENV vars
 
 
 

--- a/lib/canvas_statsd.rb
+++ b/lib/canvas_statsd.rb
@@ -3,6 +3,8 @@ require "aroi" if defined?(ActiveRecord)
 
 module CanvasStatsd
 
+  @settings = {}
+
   class ConfigurationError < StandardError; end
 
   require "canvas_statsd/statsd"
@@ -14,7 +16,7 @@ module CanvasStatsd
   require "canvas_statsd/null_logger"
 
   def self.settings
-    @settings || env_settings
+    env_settings.merge(@settings)
   end
 
   def self.settings=(value)

--- a/spec/canvas_statsd/canvas_statsd_spec.rb
+++ b/spec/canvas_statsd/canvas_statsd_spec.rb
@@ -20,7 +20,7 @@ require 'spec_helper'
 
 describe CanvasStatsd do
   before(:each) do
-    CanvasStatsd.settings = nil
+    CanvasStatsd.settings = {}
   end
 
   after(:each) do
@@ -56,13 +56,15 @@ describe CanvasStatsd do
 
     end
 
-    it 'configured settings take precedence over ENV settings' do
+    it 'configured settings are merged into and take precedence over any existing ENV settings' do
       ENV['CANVAS_STATSD_HOST'] = 'statsd.example.org'
       ENV['CANVAS_STATSD_NAMESPACE'] = 'canvas'
 
-      settings = {foo: 'bar', baz: 'apple'}
+      settings = {foo: 'bar', baz: 'apple', host: 'statsd.example-override.org'}
       CanvasStatsd.settings = settings
-      expect(CanvasStatsd.settings).to eq settings
+
+      expect(CanvasStatsd.settings).to eq(CanvasStatsd.env_settings.merge(settings))
+      expect(CanvasStatsd.settings[:host]).to eq(settings[:host])
     end
   end
 


### PR DESCRIPTION
From the README, it's not immediately clear that user provided `settings` are used in lieu of any existing `ENV` variables. This commit cleans up that language and provides the functionality so that a user can setup shared configuration across different environments (e.g. in an initializer)  and still leverage any `ENV` specific config that may be in place.
